### PR TITLE
Set compiler version

### DIFF
--- a/waffle-config.json
+++ b/waffle-config.json
@@ -1,5 +1,6 @@
 {
   "sourcesPath": "./contracts",
   "targetPath": "./build",
-  "npmPath": "./node_modules"
+  "npmPath": "./node_modules",
+  "compilerVersion": "0.5.16"
 }


### PR DESCRIPTION
`npm test` fails with the following error.

```
Source file requires different compiler version (current compiler is 0.6.4+commit.1dca32f3.Emscripten.clang - note that nightly builds are considered to be strictly less than the released version
pragma solidity ^0.5.16;
^----------------------^
```

This commit fixes the test by setting the compiler verion in `waffle-config.json`